### PR TITLE
chore(docs): add links to our Github profiles in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ During the workshop, students will fork a public repository, add their contribut
 
 ## Creators
 
-- Sooraj Modi
-- Marshall Asch
+- [Sooraj Modi](https://github.com/SoorajModi)
+- [Marshall Asch](https://github.com/MarshallAsch)
 
 ## Prerequisites
 


### PR DESCRIPTION
**Why**
This change is being made so that our names in the readme link to our Github accounts

---

**What**
Add markdown links to the readme. 

---

**Verification**
The links on our names should work.

---

**Checklist:**

<!-- To check an item, fill the brackets with the letter `x`; the result should look like `[x]`.-->

- [ ] This contribution abides by all rules
- [ ] Set yourself as the `Assignee`
- [ ] Set @SoorajModi and @MarshallAsch as the `Reviewers`
